### PR TITLE
FIX: testing fails whenever an agreement cannot be reached

### DIFF
--- a/environment/negotiation.py
+++ b/environment/negotiation.py
@@ -47,7 +47,7 @@ class NegotiationEnv(gym.Env):
 
     def step(self, action: Inform) -> tuple[Action, float, bool, None]:
         if self.progress.get(time.time() * 1000) == 1:
-            return None, 0.0, True, None  # observation, reward, done, info
+            return None, 0.0, True, 0.0  # observation, reward, done, info
 
         self.opponent.notifyChange(ActionDone(action))
 
@@ -62,7 +62,7 @@ class NegotiationEnv(gym.Env):
         observation: Action = self.opponent.notifyChange(YourTurn())
 
         if self.progress.get(time.time() * 1000) == 1:
-            return None, 0.0, True, None  # observation, reward, done, info
+            return None, 0.0, True, 0.0  # observation, reward, done, info
 
         if isinstance(observation, Accept):
             bid = observation.getBid()


### PR DESCRIPTION
The average reward for a test cannot be calculated if any of the negotiations did not reach an agreement. 
Changed the step function from returning None to a reward of 0.0 to fix this.