### PR TITLE
Fix incompatible log filenames and non-encoded profile URIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs
 
 checkpoint.pkl
 *.sbatch
+.idea

--- a/agent/ppo_agent.py
+++ b/agent/ppo_agent.py
@@ -179,7 +179,7 @@ class PPOAgent:
             log_dir_path.mkdir(parents=True)
 
         # track total training time
-        start_time = time.strftime("%Y-%m-%d_%H:%M:%S")
+        start_time = time.strftime("%Y-%m-%d_%H%M%S")
         log_file_path = log_dir_path.joinpath(f"{start_time}.csv")
 
         print(f"Started training at (GMT) : {start_time}")

--- a/environment/domains.py
+++ b/environment/domains.py
@@ -14,8 +14,8 @@ from uri.uri import URI
 def get_domains(domains_dir: Union[str, Path]) -> tuple[tuple[URI, URI]]:
     dir = Path(domains_dir)
 
-    A_profiles = (URI(f"file:{x}") for x in sorted(dir.glob("domain*/profileA.json")))
-    B_profiles = (URI(f"file:{x}") for x in sorted(dir.glob("domain*/profileB.json")))
+    A_profiles = (URI(f"file:{x.as_posix()}") for x in sorted(dir.glob("domain*/profileA.json")))
+    B_profiles = (URI(f"file:{x.as_posix()}") for x in sorted(dir.glob("domain*/profileB.json")))
     domains = tuple(zip(A_profiles, B_profiles))
 
     return domains


### PR DESCRIPTION
Colons ":" are not allowed in Windows filenames, so the start_time variable in ppo_agent has been updated to not use colons in the hours:minutes:seconds. Before it was 17:55:00, now 175500.

Furthermore, when the domains were being read from the file structure, the URIs were not being encoded as file paths, therefore for Windows the backslashes were being replaced by "%5C" when uri.getPath() was called by GeniusWeb when trying to retreive profiles for training. Now the as.posix() method from pathlib in Python is used to ensure the filepath is saved as a literal directory in the URIs of the Domain