### PR TITLE
Fix an issue with low test rewards

### DIFF
--- a/agent/utils/ppo.py
+++ b/agent/utils/ppo.py
@@ -194,8 +194,11 @@ class PPO:
         self.buffer.clear()
     
     def save(self, checkpoint_path):
-        torch.save(self.policy_old.state_dict(), checkpoint_path)
+        torch.save({'action_std': self.action_std, 'policy': self.policy_old.state_dict()}, checkpoint_path)
    
     def load(self, checkpoint_path):
-        self.policy_old.load_state_dict(torch.load(checkpoint_path, map_location=lambda storage, loc: storage))
-        self.policy.load_state_dict(torch.load(checkpoint_path, map_location=lambda storage, loc: storage))
+        torch_load = torch.load(checkpoint_path, map_location=lambda storage, loc: storage)
+        self.policy_old.load_state_dict(torch_load['policy'])
+        self.policy.load_state_dict(torch_load['policy'])
+        self.policy_old.set_action_std(torch_load['action_std'])
+        self.policy.set_action_std(torch_load['action_std'])


### PR DESCRIPTION
Store the action_std variable when saving the model

Previously, the action_std value was not stored anywhere, so when testing the default value of 0.6 was used, giving significantly lower rewards during testing